### PR TITLE
Set `global-ignore-conda-prefix`

### DIFF
--- a/recipe/global-ignore-conda-prefix
+++ b/recipe/global-ignore-conda-prefix
@@ -1,1 +1,0 @@
-If this file is present, `pixi global` will not set the CONDA_PREFIX environment variable during activation of the executable

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,6 +19,7 @@ build:
   script:
     content:
       # Tell `pixi global` to not set CONDA_PREFIX during activation
+      # https://pixi.sh/dev/global_tools/introduction/#opt-out-of-conda_prefix
       - if: win
         then:
           - if not exist "%PREFIX%\\etc\\pixi" mkdir "%PREFIX%\\etc\\pixi"


### PR DESCRIPTION
As described in https://github.com/astral-sh/ty/issues/796, `ty` isn't currently usable when installed with `pixi global`.
 This [PR](https://github.com/prefix-dev/pixi/pull/4619) introduces a feature in Pixi,
 which tells pixi global to *not* set `CONDA_PREFIX` during activation.

 Here we make use of that feature

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
