### PR TITLE
Move global-ignore-conda-prefix to etc/pixi/ty directory

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,18 +15,18 @@ source:
   sha256: e941e9a9d1e54b03eeaf9c3197c26a19cf76009fd5e41e16e5657c1c827bd6d3
 
 build:
-  number: 1
+  number: 2
   script:
     content:
       # Tell `pixi global` to not set CONDA_PREFIX during activation
       # https://pixi.sh/dev/global_tools/introduction/#opt-out-of-conda_prefix
       - if: win
         then:
-          - if not exist "%PREFIX%\\etc\\pixi" mkdir "%PREFIX%\\etc\\pixi"
-          - type nul > "%PREFIX%\\etc\\pixi\\global-ignore-conda-prefix"
+          - if not exist "%PREFIX%\\etc\\pixi" mkdir "%PREFIX%\\etc\\pixi\\ty"
+          - type nul > "%PREFIX%\\etc\\pixi\\ty\\global-ignore-conda-prefix"
         else:
-          - mkdir -p "${PREFIX}/etc/pixi"
-          - touch "${PREFIX}/etc/pixi/global-ignore-conda-prefix"
+          - mkdir -p "${PREFIX}/etc/pixi/ty"
+          - touch "${PREFIX}/etc/pixi/ty/global-ignore-conda-prefix"
       - maturin build --release
       - ${{ PYTHON }} -m pip install --find-links=ruff/target/wheels ty
       - cd ruff


### PR DESCRIPTION
We moved the ignore-conda-prefix file to its own namespace to avoid ignoring if you only have certain package in your environment but don't expose it

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
